### PR TITLE
Add api key to travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 language: node_js
 node_js:
-  - "12"
-
+- '12'
 script:
-  - npm test 
-  - npm run build
-
+- npm test
+- npm run build
 notifications:
   email: false
-  
 deploy:
   provider: heroku
   app: hitch-a-ride-app
   skip_cleanup: true
   on:
     branch: main
+  api_key:
+    secure: AQVTwK3EUq6UetZGins1ssPWkCl2nkg9nslR0YqC2GVqb2JSSGOlebqfkOvR0U2oSumAqcm9F4DOHJW7N1iXg2bQfaehsezj+Bj5dgEv+vAQ3pjWf4s3Ab9E6efPINL25voZyHL2/P77bLnmQa6QFXLqLlLT0OSngRTLr34UzBZwS/SkKEU/GRym6nkSpGD/EGk19rGhMcXQZzPtNsvbzHX73ppn88vn3Iu2vorlugdWfmo1GaeQuqmOMlaXJuk8Yi4ViVisMHlXsnEqRGYu/7hkujkLdeasukOnFQPPooMYBOYbFoJ/E2GPJ92ST+qVhZs3qcMjgVHQTqbGVf+vzZ59VuUCUAL00Gyss2/jA1po/dIgc8SNpwfpvZAUxzTXo3pdMgWsg8NOR/GdqcB4SzEaOarhmWFG4jpcChgCg7YKeYb/v4ghDjlUgYFp6m6OJJt9etpyeOhFqaALCBoSrIr6UU91Hs8M1p42D9gZp2AfQC+0PUmtzF0cafMwpCn2kHxfXS1s7Ay2Dnrbjh1gqWketHwI/cFJHIh6488ludwqI2hxRG+495KrI1TeG/vyxBLS9Dd9rpeefAYQYhEa1syrlxRTmLy6ik1OBR+ug1UzcR+z0Pta+gFdnZlVXMcVy3BEBUpDT9n+MpNkW3wAYHXrZALqhYIcV44yEm6Y/DM=


### PR DESCRIPTION
## Is this a fix or a feature?

This is fix.

## What is the change?

N/a.

## What does it fix?

Add travis dependency and API key from heroku to `travs.yml` file

## Where should the reviewer start?

In the `travis.yml` file should now reflect the API key

## How should this be tested?

When this branch is merged, a successful build should be complied in Heroku and on Travis

## Relevant ScreenShots
